### PR TITLE
[BUG] screenshot.png does not appear in skin selector

### DIFF
--- a/Classes/Domain/Model/Theme.php
+++ b/Classes/Domain/Model/Theme.php
@@ -80,7 +80,7 @@ class Tx_Themes_Domain_Model_Theme extends Tx_Extbase_DomainObject_AbstractEntit
 			$this->author['company'] = $EM_CONF[$this->getExtensionName()]['author_company'];
 
 			if(is_file($path . 'screenshot.png')) {
-				$this->previewImage      = t3lib_extMgm::extPath($this->getExtensionName()) . 'Resources/Public/Images/screenshot.png';
+				$this->previewImage      = $path . 'screenshot.png';
 			} else {
 				$this->previewImage      = t3lib_extMgm::extRelPath('themes')               . 'Resources/Public/Images/screenshot.gif';
 			}


### PR DESCRIPTION
With this patch the path to the image is correct but this error occors:
Could not get image resource for "xxx/typo3conf/ext/basictemplate/Configuration/Theme/screenshot.png".
