### PR TITLE
Fixed undefined object if no preset is configured

### DIFF
--- a/Classes/Utilities/ApplicationContext.php
+++ b/Classes/Utilities/ApplicationContext.php
@@ -74,7 +74,7 @@ class ApplicationContext {
 				continue;
 			}
 		}
-		if($activePreset->getName() === 'Development') {
+		if($activePreset && $activePreset->getName() === 'Development') {
 			return true;
 		}
 		return false;


### PR DESCRIPTION
If TYPO3 is not in development context and no preset is selected, $activePreset is undefined.

I added a simple check if it's defined or not.