### PR TITLE
Corrected constraints for Ext:static_info_tables

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -33,7 +33,7 @@ $EM_CONF[$_EXTKEY] = array(
 	'constraints' => array(
 		'depends' => array(
 			'typo3' => '7.6.0-7.6.99',
-			'static_info_tables' => '6.0.10-6.2.1',
+			'static_info_tables' => '6.3.0-6.3.99',
 			'yaml_parser' => '1.0.0-1.0.99',
 		),
 		'conflicts' => array(


### PR DESCRIPTION
Problem with install via composer:
`typo3-ter/themes 2.5.0 requires typo3-ter/static-info-tables >= 6.0.10, <= 6.2.1 -> no matching package found.`

Starting with 6.3.0 static-info-tables supports TYPO3 CMS 7.6, which in return is an requirement for themes 2.5.0.

Solution:
Set the version dependency to 6.3.0-6.3.99

